### PR TITLE
ENH: Add an initial Jupyter notebook to plot the ITK performance.

### DIFF
--- a/itk_mean_execution_time_plot.ipynb
+++ b/itk_mean_execution_time_plot.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" seamless=\"seamless\" src=\"https://plot.ly/~jhlegarreta/8.embed\" height=\"525px\" width=\"100%\"></iframe>"
+      ],
+      "text/plain": [
+       "<plotly.tools.PlotlyDisplay object>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from datetime import datetime\n",
+    "import json\n",
+    "import os\n",
+    "from os.path import join as pjoin\n",
+    "import pandas as pd\n",
+    "import plotly.plotly as py\n",
+    "import plotly.graph_objs as go\n",
+    "\n",
+    "\n",
+    "DATA_DIR = './data'\n",
+    "\n",
+    "probes_mean_time = []\n",
+    "config_dates = []\n",
+    "\n",
+    "for filename in os.listdir(DATA_DIR):\n",
+    "\n",
+    "    filename = pjoin(DATA_DIR, filename)\n",
+    "    with open(filename) as data_file:\n",
+    "        data_string = data_file.read()\n",
+    "        try:\n",
+    "            df = json.loads(data_string)\n",
+    "            probes_mean_time.append(df['Probes'][0]['Mean'])\n",
+    "            config_dates.append(df['ITK_MANUAL_BUILD_INFO']['GIT_CONFIG_DATE'])\n",
+    "        except ValueError:\n",
+    "            print(repr(data_string))\n",
+    "\n",
+    "data = [go.Scatter(\n",
+    "          x=config_dates,\n",
+    "          y=probes_mean_time)]\n",
+    "py.sign_in('name', 'API_key')\n",
+    "py.iplot(data)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add an initial Jupyter notebook to plot the ITK performance: scatter
plot over time of the mean probes time for all `json` files that dwell
in the `data` folder.