### PR TITLE
ENH: Add `__pycache__` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gz
 .idea
 .ipynb_checkpoints/
+__pycache__/


### PR DESCRIPTION
Add `__pycache__` to `.gitignore` to avoid tracking such folders.