### PR TITLE
ENH: Fix security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ terminado==0.8.1
 testpath==0.3.1
 tornado==5.0
 traitlets==4.3.2
-urllib3==1.24.1
+urllib3>=1.24.2
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.1.4


### PR DESCRIPTION
Fix security alerts identified by GitHub concerning the `urllib3` package
version: update the version in the `requirements.txt` file to the
recommended version.