### PR TITLE
ENH: Upgrade `jupyter_core`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jsonschema==2.6.0
 jupyter==1.0.0
 jupyter-client==5.2.2
 jupyter-console==5.2.0
-jupyter-core==4.4.0
+jupyter-core==4.11.2
 kiwisolver==1.0.1
 MarkupSafe==1.0
 matplotlib==3.0.2


### PR DESCRIPTION
Upgrade to `jupyter_core>=4.11.2` following the dependabot security alert in:
https://github.com/jhlegarreta/ITKPerformancePlot/security/dependabot/7